### PR TITLE
choose mesh algorithm argument

### DIFF
--- a/waveguidemodes/mesh.py
+++ b/waveguidemodes/mesh.py
@@ -164,6 +164,7 @@ def mesh_from_polygons(
     default_resolution_min: float = 0.01,
     default_resolution_max: float = 0.5,
     filename: Optional[str] = None,
+    gmsh_algorithm: int = 5,
 ):
 
     import gmsh
@@ -176,6 +177,7 @@ def mesh_from_polygons(
         # geometry = pygmsh.occ.geometry.Geometry()
         geometry.characteristic_length_min = default_resolution_min
         geometry.characteristic_length_max = default_resolution_max
+        gmsh.option.setNumber("Mesh.Algorithm", gmsh_algorithm)
 
         model = geometry.__enter__()
 
@@ -381,12 +383,12 @@ if __name__ == "__main__":
     polygons["box"] = box
 
     resolutions = {}
-    resolutions["core"] = {"resolution": 0.01, "distance": 2}
-    resolutions["core2"] = {"resolution": 0.01, "distance": 2}
+    resolutions["core"] = {"resolution": 0.03, "distance": 0.5}
+    resolutions["core2"] = {"resolution": 0.03, "distance": 0.5}
     # resolutions["clad"] = {"resolution": 0.1, "dist_min": 0.01, "dist_max": 0.3}
 
 
-    mesh = mesh_from_polygons(polygons, resolutions, filename="mesh.msh", default_resolution_max=.3)
+    mesh = mesh_from_polygons(polygons, resolutions, filename="mesh.msh", default_resolution_max=.3, gmsh_algorithm=8)
 
     # gmsh.write("mesh.msh")
     # gmsh.clear()


### PR DESCRIPTION
User can now specific a **global** gmsh algorithm for meshing (default to 5: DeLaunay)

For instance, here is the difference between 5 (DeLaunay)

![image](https://user-images.githubusercontent.com/46427609/200035677-20e9c052-bd10-4202-ba21-068cdf12b65a.png)

and 8 (DeLaunay for quads):

![image](https://user-images.githubusercontent.com/46427609/200035767-e4dde357-00a8-4a1b-898a-2f0e34b683c6.png)

Possible improvement:

* Allow selection of algorithm per mesh entity (a new parameter in resolution dict)
* Give the user more control by also giving mesh recombination options
* Map gmsh integer meshing strategy codes to names